### PR TITLE
Fixed #30 "Stickers send as links even when in an available channel"

### DIFF
--- a/FreeStickers.plugin.js
+++ b/FreeStickers.plugin.js
@@ -3772,16 +3772,19 @@ function checkPermission(flag, user, channel) {
 }
 
 const StickerSendability = isSendableStickerMangled[1];
+StickerSendability.SENDABLE = 0;
+StickerSendability.NONSENDABLE = 1;
 const getStickerSendability = getStickerSendabilityMangled[1];
 
 BdApi.Patcher.instead('FreeStickers', StickerSendabilityModule, isSendableStickerMangled[0], (thisObject, methodArguments, originalMethod) => {
     let stickerSendability = getStickerSendability.apply(thisObject, methodArguments);
 
     if(stickerSendability === StickerSendability.SENDABLE) {
+        console.log("pp");
         return true;
     }
 
-    if(stickerSendability !== StickerSendability.NONSENDABLE) {
+    if(stickerSendability === StickerSendability.NONSENDABLE) {
         const [sticker, user, channel] = methodArguments;
 
         if(channel.type === 1/*DM*/ || channel.type === 3/*GROUP_DM*/) {

--- a/FreeStickers.plugin.js
+++ b/FreeStickers.plugin.js
@@ -3780,7 +3780,6 @@ BdApi.Patcher.instead('FreeStickers', StickerSendabilityModule, isSendableSticke
     let stickerSendability = getStickerSendability.apply(thisObject, methodArguments);
 
     if(stickerSendability === StickerSendability.SENDABLE) {
-        console.log("pp");
         return true;
     }
 


### PR DESCRIPTION
- `StickerSendability.SENDABLE` and `StickerSendability.NONSENDABLE` were both `undefined`.
- Code mistakenly checks for when a sticker is not nonsendable rather than if it is unsendable on line 3787.